### PR TITLE
Update README.md to include TEST_PROJECT_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ with Java.
 
 - appengine-push
 
-  A sample for push subscription running on [Google App Engine][1].
+  A sample for push subscription running on [Google App Engine](https://cloud.google.com/appengine/docs).
 
 - cmdline-pull
 
   A command line sample for pull subscription.
 
-[1]: https://cloud.google.com/appengine/docs
+- dataflow
+
+  Few samples for [Cloud Dataflow](https://cloud.google.com/dataflow/) streaming.

--- a/cmdline-pull/README.md
+++ b/cmdline-pull/README.md
@@ -27,6 +27,9 @@ Install Maven and Java7.
   - GOOGLE_APPLICATION_CREDENTIALS: the file path to the downloaded JSON file.
 
 ## Build the application
+- Set the following environment variable.
+  - TEST_PROJECT_ID: the ID of your Google Cloud project.
+  - note: the above environment variable is only required during the build phase.
 
 ```
 $ mvn package


### PR DESCRIPTION
TEST_PROJECT_ID is required during the test phase of 'mvn package'; otherwise the process fails with a cryptic error message. The PubSub integration test in cmdline-pull relies upon this environment variable so it is important for this to be in the documented instructions.
