### PR TITLE
Update README.md to include TEST_PROJECT_ID

### DIFF
--- a/cmdline-pull/README.md
+++ b/cmdline-pull/README.md
@@ -27,6 +27,9 @@ Install Maven and Java7.
   - GOOGLE_APPLICATION_CREDENTIALS: the file path to the downloaded JSON file.
 
 ## Build the application
+- Set the following environment variable.
+  - TEST_PROJECT_ID: the ID of your Google Cloud project.
+  - note: the above environment variable is only required during the build phase.
 
 ```
 $ mvn package


### PR DESCRIPTION
_TEST_PROJECT_ID_ is required during the test phase of '_mvn package_'; otherwise the process fails with a cryptic error message. The PubSub integration test in cmdline-pull relies upon this environment variable so it is important for this to be in the documented instructions.
